### PR TITLE
Adding a chefignore

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,54 @@
+# Ignore examples from the cookbook root
+chef.rb
+example.rb
+
+## OS
+.DS_Store
+Icon?
+nohup.out
+
+## EDITORS
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED
+a.out
+*.o
+*.pyc
+*.so
+
+## OTHER SCM
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+## Don't send rspecs up in cookbook
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+features/*
+
+## SCM
+.gitignore
+
+# Berkshelf
+Berksfile
+Berksfile.lock
+cookbooks/*
+
+# Vagrant
+.vagrant
+.cache


### PR DESCRIPTION
Adding a chefingore to ignore the example files in the cookbook root, as well as the typical OS & editior stuff.